### PR TITLE
Fix pagination current page after repeat visit

### DIFF
--- a/client/src/component/Pagination/Pagination.tsx
+++ b/client/src/component/Pagination/Pagination.tsx
@@ -22,12 +22,14 @@ export const Pagination = ({
   totalRecords = 0,
   pageLimit = 5,
   recordLimit = 5,
+  currentOffset,
   onCurrentPage,
 }: Props) => {
   const totalPages = Math.ceil(totalRecords / pageLimit);
   if (totalRecords === 0 || totalPages === 1) return null;
 
-  const [currentPage, setCurrentPage] = useState(1);
+  const initialPage = Math.floor(currentOffset / pageLimit) + 1;
+  const [currentPage, setCurrentPage] = useState(initialPage);
 
   const getRange = () => {
     if (totalPages < pageLimit) return range(1, totalPages);

--- a/client/src/component/Pagination/types.ts
+++ b/client/src/component/Pagination/types.ts
@@ -1,4 +1,5 @@
 interface OwnProps {
+  currentOffset: number;
   totalRecords?: number;
   pageLimit?: number;
   recordLimit?: number;

--- a/client/src/pages/ForumPage/index.tsx
+++ b/client/src/pages/ForumPage/index.tsx
@@ -25,6 +25,7 @@ import {
   getIsNewTopicLoading,
   getNewTopicError,
   getNewTopicId,
+  getOffset,
   getTotal,
 } from "@selectors/widgets/forumPage";
 
@@ -38,6 +39,7 @@ const rulesFieldsProfile = {
 
 export const ForumBlock = ({
   total,
+  offset,
   newCurrentPageThunk,
   fetchNewTopicThunk,
   isNewTopicLoading,
@@ -82,6 +84,7 @@ export const ForumBlock = ({
           <ForumList className="forum__list forum__list_column" />
         </div>
         <Pagination
+          currentOffset={offset}
           totalRecords={total}
           pageLimit={FORUM_RECORD_LIMIT}
           recordLimit={TOPIC_MESSAGES_RECORD_LIMIT}
@@ -142,6 +145,7 @@ export const ForumBlock = ({
 };
 
 const mapStateToProps = (state: State) => ({
+  offset: getOffset(state),
   total: getTotal(state),
   newTopicId: getNewTopicId(state),
   isNewTopicLoading: getIsNewTopicLoading(state),

--- a/client/src/pages/ForumPage/types.ts
+++ b/client/src/pages/ForumPage/types.ts
@@ -2,6 +2,7 @@ import { ForumAddTopic } from "@resolvers/forum/types";
 
 export interface Props {
   total: number;
+  offset: number;
   newCurrentPageThunk: (page: number) => Promise<void>;
   fetchNewTopicThunk: (data: ForumAddTopic) => Promise<void>;
   isNewTopicLoading: boolean;

--- a/client/src/pages/LeaderBoard/index.tsx
+++ b/client/src/pages/LeaderBoard/index.tsx
@@ -14,7 +14,10 @@ import {
 } from "@constants/index";
 
 import { newCurrentPage } from "@thunks/widgets/leaderboard";
-import { getIdsLeaderboardCount } from "@selectors/widgets/leaderboardPage";
+import {
+  getCursor,
+  getIdsLeaderboardCount,
+} from "@selectors/widgets/leaderboardPage";
 
 import type { State } from "@reducers/index";
 import type { Props } from "./types";
@@ -24,6 +27,7 @@ import "./style.scss";
 export const LeaderBoardBlock = ({
   idsLeaderboardCount,
   newCurrentPageThunk,
+  offset,
 }: Props) => {
   const { t } = useTranslation();
 
@@ -41,6 +45,7 @@ export const LeaderBoardBlock = ({
           totalRecords={idsLeaderboardCount}
           recordLimit={LEADERBOARD_RECORD_LIMIT}
           pageLimit={LEADERBOARD_PAGE_LIMIT}
+          currentOffset={offset}
         />
       </Wrapper>
     </>
@@ -49,6 +54,7 @@ export const LeaderBoardBlock = ({
 
 const mapStateToProps = (state: State) => ({
   idsLeaderboardCount: getIdsLeaderboardCount(state),
+  offset: getCursor(state),
 });
 
 const mapDispatchToProps = {

--- a/client/src/pages/LeaderBoard/types.ts
+++ b/client/src/pages/LeaderBoard/types.ts
@@ -1,4 +1,5 @@
 export interface Props {
   idsLeaderboardCount: number;
+  offset: number;
   newCurrentPageThunk: (page: number) => Promise<void>;
 }


### PR DESCRIPTION
если пользователь смотрел 2 страницу лидерборда или форума, а затем выходил в меню, то при возвращении на лидерборд попадал по факту на 2 страницу списка, но в пагинации выделялась 1 страница - fixed